### PR TITLE
Update `G4Hist` to changes in `FHist@0.11`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,7 +34,7 @@ Geant4_julia_jll = "0.1.17"
 GeometryBasics = "0.4"
 IGLWrap_jll = "2.4.0"
 julia = "1.9"
-FHist = "0.10"
+FHist = "0.11"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/ext/G4Hist/G4Hist.jl
+++ b/ext/G4Hist/G4Hist.jl
@@ -3,8 +3,8 @@ module G4Hist
     using FHist
     using Geant4.SystemOfUnits
 
-    const Hist1DType = typeof(Hist1D(bins=range(0,1,10)))
-    const Hist2DType = typeof(Hist2D(bins=(range(0,1,10),range(0,1,10))))
+    const Hist1DType = typeof(Hist1D(;binedges=range(0,1,10)))
+    const Hist2DType = typeof(Hist2D(;binedges=(range(0,1,10),range(0,1,10))))
     
     _getvalue(unit::Symbol) = getfield(Geant4.SystemOfUnits, unit)
     _getvalue(units::Tuple{Symbol,Symbol}) = (getfield(Geant4.SystemOfUnits, units[1]), getfield(Geant4.SystemOfUnits, units[2]))
@@ -19,7 +19,7 @@ module G4Hist
         unit::Symbol
         unitval::Float64
     end
-    Geant4.H1D(title, nbins, min, max, unit=:nounit) = H1D(title, Hist1D(Float64;bins=range(min,max,nbins+1),overflow=true), unit, _getvalue(unit))
+    Geant4.H1D(title, nbins, min, max, unit=:nounit) = H1D(title, Hist1D(;counttype=Float64,binedges=range(min,max,nbins+1),overflow=true), unit, _getvalue(unit))
 
     Base.push!(h::H1D, v, w=1) = push!(h.hist, v/h.unitval, w)
     Base.merge!(h1::H1D, h2::H1D) = merge!(h1.hist, h2.hist)
@@ -35,7 +35,7 @@ module G4Hist
         unit::Tuple{Symbol,Symbol}
         unitval::Tuple{Float64,Float64}
     end
-    Geant4.H2D(title, xbins, xmin, xmax, ybins, ymin, ymax, units=(:nounit, :nounit)) = H2D(title, Hist2D(Float64;bins=(range(xmin,xmax,xbins+1), range(ymin,ymax, ybins+1)), overflow=true), units, _getvalue(units))
+    Geant4.H2D(title, xbins, xmin, xmax, ybins, ymin, ymax, units=(:nounit, :nounit)) = H2D(title, Hist2D(;counttype=Float64,binedges=(range(xmin,xmax,xbins+1),range(ymin,ymax, ybins+1)),overflow=true), units, _getvalue(units))
 
     Base.push!(h::H2D, u, v, w=1) = push!(h.hist, u/h.unitval[1], v/h.unitval[2], w)
     Base.merge!(h1::H2D, h2::H2D) = merge!(h1.hist, h2.hist) 

--- a/ext/G4Vis/G4Display.jl
+++ b/ext/G4Vis/G4Display.jl
@@ -79,7 +79,7 @@ function drawEvent(evtdisp::G4JLEventDisplay)
             end
             push!(points, Point3{Float64}(NaN, NaN, NaN))
         end
-        lines!(s, points, color=settings.trajectories.color, tranparency=false, overdraw=false)
+        lines!(s, points, color=settings.trajectories.color, transparency=false, overdraw=false)
     end
     #wait_for_key("Press any key to continue with next event")
 end


### PR DESCRIPTION
There were some breaking syntax changes in `FHist@0.11` that require `Geant4.jl` to be fixed to `FHist@0.10`.
This results in the fact, that `Geant4` is downgraded to the version `v0.1.13` when `FHist` is upgraded to `v0.11`.

In this PR, I tried to update the code to the breaking changes in `FHist@0.11`.

The tests will fail because the `G4Examples` are also partly written in the old `FHist` syntax.
I will also open a PR to `G4Examples` where these breaking changes are fixed.

