### PR TITLE
Add Downgrade workflow and bump compats of `[weakdeps]`

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,28 @@
+name: Downgrade
+env:
+  JULIA_NUM_THREADS: 4
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ['lts']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/julia-downgrade-compat@v1
+        with:
+          skip: Pkg,TOML
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: false

--- a/Project.toml
+++ b/Project.toml
@@ -29,12 +29,16 @@ G4Vis = ["Makie", "Colors", "StaticArrays", "Rotations", "LinearAlgebra", "IGLWr
 
 [compat]
 CSV = "0.10"
-CxxWrap = "0.16"
+Colors = "0.12.9, 0.13"
+CxxWrap = "0.16, 0.17"
+FHist = "0.11"
 Geant4_julia_jll = "0.2"
 GeometryBasics = "0.5"
 IGLWrap_jll = "2.6.0"
+Makie = "0.22, 0.23"
+Rotations = "1"
+StaticArrays = "1"
 julia = "1.9"
-FHist = "0.11"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
I added the Downgrade workflow, which sets all packages to the lowest `[compat]` in the `Project.toml` and runs the tests. Right now, not many packages and checks are run in the tests, so this workflow might not be super effective. But it checks for compatibility between the packages and might be nice to have for the future.

I am running the tests on `lts` (`julia-1.10`). On `julia-1.11`, some tests would fail because of StaticArrays (only works on `julia-1.11` starting 1.5.17) and CSV (there seems to have been a fix to work on `julia-1.11` in 0.10.13) and we would have to restrict the lowest compats in the `Project.toml`, which I would like to avoid.
